### PR TITLE
Add MIT LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Emmote (@Emmotes) and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Hi @Emmotes,

Thanks for maintaining ic_servercalls — it's an incredibly useful reference for
anyone doing anything API-driven with Idle Champions.

One small gap: the repo currently has no LICENSE file, which under default copyright
means other community tools can't legally fork or reuse it even with attribution.

This PR adds an MIT LICENSE, which is:
  - The convention across Idle Champions community tooling
  - Short, permissive, and attribution-preserving
  - Low-ceremony for a fan project

If you'd prefer a different license (Apache-2.0, BSD-3-Clause, CC-BY for the rendered
docs, etc.), I'm happy to change it — or feel free to just close this PR and apply
whatever you prefer. The main thing is that having *any* clear license on the repo
unblocks the rest of the community.

Copyright holder on the MIT file is set to you (@Emmotes) — adjust as needed.